### PR TITLE
Skip empty product resources from trailing newlines

### DIFF
--- a/src/resources.ts
+++ b/src/resources.ts
@@ -22,7 +22,7 @@ server.resource(
         const csv = await baza('/products', 'GET', {}, '');
         let list: Array<Resource> = [];
         if (csv.length !== 0) {
-          const products = csv.split("\n");
+          const products = csv.split("\n").filter((product) => product.length > 0);
           list = products.map((product) => ({
             uri: `products://${product}`,
             name: product,

--- a/test/resources.test.ts
+++ b/test/resources.test.ts
@@ -41,6 +41,27 @@ describe('resources', () => {
     expect(resource).toHaveProperty('description');
   });
 
+  test('skips empty product after trailing newline', async (): Promise<void> => {
+    mock.mockImplementation(async (path, method, params, body) => {
+      if (path === '/products' && method === 'GET') {
+        return 'product1\nproduct2\n';
+      }
+      if (path === '/mcp/resource' && method === 'PUT' && params.name === 'product') {
+        return `Details for product ${params.product}`;
+      }
+      return body;
+    });
+    const answer = await once({
+      jsonrpc: '2.0' as const,
+      id: 1,
+      method: 'resources/list'
+    });
+    expect(answer.result?.resources?.map((resource) => resource.uri)).toEqual([
+      'products://product1',
+      'products://product2'
+    ]);
+  });
+
   test('fetches fake resource details', async (): Promise<void> => {
     const list = await once({
       jsonrpc: '2.0' as const,


### PR DESCRIPTION
## Summary

- filter empty product names after splitting the `/products` response
- prevent trailing newlines from producing an invalid `products://` resource
- add a regression test for a `product1\nproduct2\n` response body

Fixes #27.

## Validation

- `npm ci --ignore-scripts --no-audit --no-fund --progress=false`
- `npx jest --config jest.config.ts --no-color --ci test/resources.test.ts --coverage=false`
- `npx eslint . --config eslint.config.mjs`
- `npx tsc --target es2020 --module nodenext --outDir dist index.ts src/baza.ts src/prompts.ts src/resources.ts src/server.ts src/to_gpt.ts src/tools.ts`
- `git diff --check HEAD~1 HEAD`
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact`

## Notes

- Full `npx jest --config jest.config.ts --no-color --ci` currently fails in the existing live `baza` and server tests because the fixture token receives HTTP error responses from the Zerocracy API; the focused resource regression passes.
- `make it` was attempted, but the command hung in `npm exec @modelcontextprotocol/inspector` before producing `temp/tools.json`.
- AI-assisted contribution disclosure: I used OpenAI Codex to inspect the issue, make this focused code/test change, and run the checks above. I reviewed the resulting diff before submission.
