### PR TITLE
Wrap network failures from baza fetch calls

### DIFF
--- a/src/baza.ts
+++ b/src/baza.ts
@@ -21,7 +21,17 @@ export const baza = async function(path: string, method: string,
   if (body.length > 0) {
     meta['body'] = body;
   }
-  const response = await fetch(uri, meta);
+  let response: Response;
+  try {
+    response = await fetch(uri, meta);
+  } catch (err) {
+    const cause = err as Error;
+    const error = new Error(
+      `Network failure for ${method} ${uri}: ${cause.message}`
+    );
+    (error as Error & { cause?: unknown }).cause = err;
+    throw error;
+  }
   if (response.status != 200) {
     let error = `HTTP error ${response.status}`;
     const why = response.headers.get('X-Zerocracy-Failure');

--- a/test/baza.test.ts
+++ b/test/baza.test.ts
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
 // SPDX-License-Identifier: MIT
 
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, test, jest } from '@jest/globals';
 import { baza } from '../src/baza';
 
 describe('baza', () => {
   const before = process.env.ZEROCRACY_TOKEN;
+  const before_fetch = globalThis.fetch;
 
   beforeEach(() => {
     process.env.ZEROCRACY_TOKEN = '00000000-0000-0000-0000-000000000000';
@@ -17,6 +18,7 @@ describe('baza', () => {
     } else {
       process.env.ZEROCRACY_TOKEN = before;
     }
+    globalThis.fetch = before_fetch;
   });
 
   test('throws when ZEROCRACY_TOKEN is not set', async (): Promise<void> => {
@@ -41,5 +43,18 @@ describe('baza', () => {
     await expect(
       baza('/mcp/tool', 'PUT', {}, '')
     ).rejects.toThrow('HTTP error 303');
+  });
+
+  test('wraps network failures', async () => {
+    const cause = new TypeError('fetch failed');
+    globalThis.fetch = jest.fn(async () => {
+      throw cause;
+    }) as unknown as typeof fetch;
+    await expect(
+      baza('/products', 'GET', {}, '')
+    ).rejects.toMatchObject({
+      message: 'Network failure for GET https://www.zerocracy.com/products?: fetch failed',
+      cause
+    });
   });
 });


### PR DESCRIPTION
## Summary

- wrap rejected `fetch()` calls in `baza()` with a consistent `Error`
- preserve the original failure on the thrown error's `cause`
- add a focused regression test for network-level fetch failures

Fixes #28.

## Validation

- `npx jest --config jest.config.ts --no-color --ci test/baza.test.ts -t 'wraps network failures' --coverage=false`
- `npx eslint . --config eslint.config.mjs`
- `npx tsc --target es2020 --module nodenext --outDir dist index.ts src/baza.ts src/prompts.ts src/resources.ts src/server.ts src/to_gpt.ts src/tools.ts`
- `git diff --check HEAD~1 HEAD`
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact`

## Notes

- Full `npx jest --config jest.config.ts --no-color --ci` currently fails in the existing live `baza` and server tests because the fixture token receives HTTP error responses from the Zerocracy API; the focused network-failure regression passes.
- AI-assisted contribution disclosure: I used OpenAI Codex to inspect the issue, make this focused code/test change, and run the checks above. I reviewed the resulting diff before submission.
