### PR TITLE
#28: wrap baza fetch network failures in typed Error

### DIFF
--- a/src/baza.ts
+++ b/src/baza.ts
@@ -21,7 +21,14 @@ export const baza = async function(path: string, method: string,
   if (body.length > 0) {
     meta['body'] = body;
   }
-  const response = await fetch(uri, meta);
+  let response: Response;
+  try {
+    response = await fetch(uri, meta);
+  } catch (e) {
+    throw new Error(
+      `Network failure for ${method} ${uri}: ${(e as Error).message}`
+    );
+  }
   if (response.status != 200) {
     let error = `HTTP error ${response.status}`;
     const why = response.headers.get('X-Zerocracy-Failure');

--- a/test/baza.test.ts
+++ b/test/baza.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 // SPDX-License-Identifier: MIT
 
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from '@jest/globals';
+import { afterAll, beforeAll, beforeEach, describe, expect, jest, test } from '@jest/globals';
 import { baza } from '../src/baza';
 import { FakeBaza } from './fakes/FakeBaza';
 
@@ -45,5 +45,18 @@ describe('baza', () => {
     await expect(
       baza('/redirect', 'PUT', {}, '')
     ).rejects.toThrow('HTTP error 303');
+  });
+
+  test('wraps network failures in typed Error', async () => {
+    const mock = jest.spyOn(globalThis, 'fetch');
+    mock.mockRejectedValue(new TypeError('fetch failed'));
+    try {
+      await expect(baza('/test', 'GET', {}, '')).rejects.toThrow(Error);
+      await expect(baza('/test', 'GET', {}, '')).rejects.toThrow(
+        'Network failure for GET'
+      );
+    } finally {
+      mock.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
Problem:
`baza()` calls `fetch()` without error handling for network-level failures. When DNS resolution, TCP connection, or TLS handshake fails, a raw `TypeError("fetch failed")` propagates instead of the consistent `Error` type that callers expect.

Solution:
Wrap the `fetch()` call in try/catch and re-throw as `Error` with a descriptive message prefix:
- `Network failure for {method} {uri}: {message}`
- The existing HTTP status error handling (non-200 responses) is unchanged
- A regression test uses `jest.spyOn` to mock a `fetch` rejection and asserts the wrapped `Error` type and message

Checklist:
- [x] `npx eslint .` — 0 errors
- [x] `npx jest --config jest.config.ts --no-color --ci test/baza.test.ts -t 'wraps network'` — passed
- [x] `npx tsc --target es2020 --module nodenext --outDir dist src/baza.ts src/to_gpt.ts` — passed

Notes:
- Full `npx jest --config jest.config.ts --no-color --ci` has pre-existing failures in test/baza.test.ts and test/server.test.ts that require a real ZEROCRACY_TOKEN; the new focused regression passes in isolation
- The `Error.cause` option was intentionally omitted to stay compatible with the project's `--target es2020` TypeScript compilation