### PR TITLE
#38: fix tsconfig.json include path and migrate to SDK v1.29 prompt API

### DIFF
--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -5,11 +5,11 @@ import { z } from 'zod';
 import { to_gpt } from './to_gpt';
 import { server } from './server';
 
-// @ts-expect-error — TS2589: @modelcontextprotocol/sdk type depth limit
-server.registerPrompt(
+server.prompt(
   'investigate-productivity-bottlenecks',
-  { argsSchema: { product: z.string() } },
-  ({ product }) => ({
+  { product: z.string() },
+  // @ts-ignore — TS2589: @modelcontextprotocol/sdk type depth limit
+  ({ product }: { product: string }) => ({
     messages: [{
       role: 'user',
       content: {

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -5,9 +5,10 @@ import { z } from 'zod';
 import { to_gpt } from './to_gpt';
 import { server } from './server';
 
-server.prompt(
+// @ts-expect-error — TS2589: @modelcontextprotocol/sdk type depth limit
+server.registerPrompt(
   'investigate-productivity-bottlenecks',
-  { product: z.string() },
+  { argsSchema: { product: z.string() } },
   ({ product }) => ({
     messages: [{
       role: 'user',
@@ -22,7 +23,7 @@ server.prompt(
           Should we overhaul the roadmap, tighten CI/CD,
             enforce stricter code reviews, raise rewards, or ramp up consequences?
           Give me one specific, high-impact recommendation in a short,
-          straight-to-the-point paragraph.
+            straight-to-the-point paragraph.
           `
         )
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,11 +5,13 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 export const server = new McpServer(
   {
-    capabilities: {
-      resources: {},
-      tools: {}
-    },
     name: 'zerocracy-mcp-server',
     version: '0.0.0'
   },
+  {
+    capabilities: {
+      resources: {},
+      tools: {}
+    }
+  }
 );

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -6,7 +6,6 @@ import { baza } from './baza';
 import { to_gpt } from './to_gpt';
 import { server } from './server';
 
-// @ts-expect-error — TS2589: @modelcontextprotocol/sdk type depth limit
 server.tool(
   'give_management_advice',
   to_gpt(
@@ -21,7 +20,8 @@ server.tool(
     `
   ),
   { concern: z.string(), product: z.string() },
-  async ({ concern, product }) => {
+  // @ts-ignore — TS2589: @modelcontextprotocol/sdk type depth limit in ts-jest
+  async ({ concern, product }: { concern: string; product: string }) => {
     return ({
       content: [{
         text: await baza(

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -6,6 +6,7 @@ import { baza } from './baza';
 import { to_gpt } from './to_gpt';
 import { server } from './server';
 
+// @ts-expect-error — TS2589: @modelcontextprotocol/sdk type depth limit
 server.tool(
   'give_management_advice',
   to_gpt(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,6 @@
   },
   "include": [
     "src/**/*.ts",
-    "tests/**/*.ts"
+    "test/**/*.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+// SPDX-License-Identifier: MIT
 {
   "compilerOptions": {
     "esModuleInterop": true,


### PR DESCRIPTION
The tsconfig.json `include` field referenced `tests/` but the test directory is named `test/`. Also migrates `server.prompt` to `server.registerPrompt` for compatibility with @modelcontextprotocol/sdk v1.29, with a `@ts-expect-error` annotation for the known TS2589 type-depth limit issue.