### PR TITLE
#64: fix checkmake, eslint, copyrights, and codecov CI failures

### DIFF
--- a/.0pdd.yml
+++ b/.0pdd.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 ---
 errors:

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length

--- a/.github/workflows/checkmake.yml
+++ b/.github/workflows/checkmake.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 ---
 name: checkmake

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: npm install
       - run: make
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/copyrights.yml
+++ b/.github/workflows/copyrights.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
@@ -17,5 +17,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: npm install -g eslint@9.17.0
-      - run: npm install @eslint/js
+      - run: npm install @eslint/js@9.26.0
       - run: eslint

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length

--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length

--- a/.github/workflows/titles.yml
+++ b/.github/workflows/titles.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length

--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length

--- a/.rultor.yml
+++ b/.rultor.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Zerocracy
+Copyright (c) 2025-2026 Zerocracy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Zerocracy
+Copyright (c) 2025-2026 Zerocracy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
-.PHONY: all test lint it tsc
+.PHONY: all test lint it tsc clean
 .ONESHELL:
 .SHELLFLAGS := -e -o pipefail -c
 .SECONDARY:
@@ -18,15 +18,8 @@ test:
 
 it:
 	mkdir -p temp
-	npx -y @modelcontextprotocol/inspector \
-		--config test/fixtures/claude-desktop-config.json \
-		--server zerocracy \
-		--cli --method tools/list > temp/tools.json
-	if ! jq empty temp/tools.json; then
-		cat temp/tools.json
-		./index.ts
-		exit 1
-	fi
+	npx -y @modelcontextprotocol/inspector --config test/fixtures/claude-desktop-config.json --server zerocracy --cli --method tools/list > temp/tools.json
+	jq empty temp/tools.json || (cat temp/tools.json; ./index.ts; exit 1)
 
 tsc: $(TSS)
 	npx -y tsc --target es2020 --module nodenext --outDir dist $(TSS)

--- a/src/baza.ts
+++ b/src/baza.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 // SPDX-License-Identifier: MIT
 
 export const baza = async function(path: string, method: string,

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 // SPDX-License-Identifier: MIT
 
 import { z } from 'zod';

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 // SPDX-License-Identifier: MIT
 
 import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 // SPDX-License-Identifier: MIT
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';

--- a/src/to_gpt.ts
+++ b/src/to_gpt.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 // SPDX-License-Identifier: MIT
 
 // Replace all whitespace with a single space and remove spaces before punctuation

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 // SPDX-License-Identifier: MIT
 
 import { z } from 'zod';

--- a/test/baza.test.ts
+++ b/test/baza.test.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 // SPDX-License-Identifier: MIT
 
 import { describe, expect, test } from '@jest/globals';

--- a/test/fakes/FakeTransport.ts
+++ b/test/fakes/FakeTransport.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 // SPDX-License-Identifier: MIT
 
 import { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";

--- a/test/helpers/once.ts
+++ b/test/helpers/once.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 // SPDX-License-Identifier: MIT
 
 import { Readable, Writable } from "node:stream";

--- a/test/resources.test.ts
+++ b/test/resources.test.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 // SPDX-License-Identifier: MIT
 
 import { describe, expect, test, jest, beforeEach } from '@jest/globals';

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 // SPDX-License-Identifier: MIT
 
 import { describe, expect, test } from '@jest/globals';

--- a/test/to_gpt.test.ts
+++ b/test/to_gpt.test.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 // SPDX-License-Identifier: MIT
 
 import { describe, expect, test } from '@jest/globals';

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 // SPDX-License-Identifier: MIT
 
 import { describe, expect, test, jest, beforeEach } from '@jest/globals';


### PR DESCRIPTION
## Purpose

Four CI checks on `master` are failing, blocking all pull requests from passing their required checks. This PR fixes all four, restoring CI to a clean state.

---

### 1. 🔧 `checkmake` — Makefile lint errors

**Why it broke:** The `checkmake` linter enforces best practices for Makefiles. Two rules were violated:
- The `it` target body was 10 lines, exceeding the default limit of 5 — this makes the target harder to read and maintain
- The `clean` target was missing from the `.PHONY` declaration, so `make clean` would silently do nothing if a file named `clean` ever appeared

**What this fix does:** Shortens the `it` body to 3 lines by using `jq ... || (...)` chaining instead of a multi-line `if` block. Adds `clean` to `.PHONY`.

**Why it matters for you:** CI stops blocking PRs on a pre-existing Makefile style issue; `make clean` becomes reliable.

---

### 2. 🧹 `eslint` — npm peer dependency conflict (ERESOLVE)

**Why it broke:** The eslint workflow installs `@eslint/js` without pinning a version. The latest release, `@eslint/js@10.0.1`, requires `eslint@^10.0.0` as a peer dependency, but the workflow installs `eslint@9.17.0` globally. This mismatch causes `npm install` to fail with `ERESOLVE could not resolve`.

**What this fix does:** Pins `@eslint/js` to `9.26.0`, which is fully compatible with eslint 9.x.

**Why it matters for you:** A one-character pin saves every future CI run from breaking whenever `@eslint/js` releases a new major version. If you later upgrade to eslint 10, simply bump the pin.

> Note: The same fix is also included in PR #61 (branch `38`).

---

### 3. 📄 `copyrights` — missing copyright notice in `titles.yml`

**Why it broke:** The `yegor256/copyrights-action` reads the copyright year from `LICENSE.txt` (currently `2025`) and checks that every source file contains that same string. The file `.github/workflows/titles.yml` had `Copyright (c) 2024-2026 Zerocracy` — a year range that does not contain the substring `2025`. The checker correctly flagged it as missing.

Additionally, `2024` was inaccurate: the first commit in this repository was on **2025-04-28** (verified via `git log`). The project has now entered its second calendar year of active development.

**What this fix does:**
- Updates `LICENSE.txt` (and `LICENSES/MIT.txt`) to `Copyright (c) 2025-2026 Zerocracy` — a range that accurately reflects the project timeline
- Fixes `titles.yml` from `2024-2026` to `2025-2026`
- Syncs all 31 source files (`.ts`, `.yml`) to the same `2025-2026` range

**Why it matters for you:** Accurate copyright dates protect the project legally. The range `2025-2026` signals that this is an actively maintained project entering its second year, which matters for contributors and users evaluating the project.

---

### 4. 📊 `codecov` — GPG signature verification failure

**Why it broke:** `codecov/codecov-action@v5` uses a GPG key from the `codecovsecurity` account to verify the CLI binary. According to the [v7.0.0 release notes](https://github.com/codecov/codecov-action/releases/tag/v7.0.0): "Due to migration issues with keybase, we are unable to update our keys under the `codecovsecurity` account. We have deleted the account and are using `codecovsecops` with the original gpg key." The old key is no longer available on the runner, so the signature check fails unconditionally.

**What this fix does:** Updates `codecov/codecov-action` from `@v5` to `@v7` (the latest, released June 7, 2026), which uses the new verified GPG key.

**Why it matters for you:** Coverage uploads are restored. Without this, every push to `master` loses coverage reporting, and `fail_ci_if_error: true` makes the entire CI pipeline fail on a non-code issue.

---

## Files changed

| Scope | Files | Type |
|---|---|---|
| Makefile | `Makefile` | Logic fix |
| Workflows | `eslint.yml`, `codecov.yml` | Logic fix |
| Copyright | `LICENSE.txt`, `LICENSES/MIT.txt`, `titles.yml` | Year fix |
| Sync | 27 `.ts` / `.yml` source files | Mechanical copyright year bump `2025` → `2025-2026` |