### PR TITLE
#68: add clean target recipe to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,6 @@ it:
 
 tsc: $(TSS)
 	npx -y tsc --target es2020 --module nodenext --skipLibCheck --outDir dist $(TSS)
+
+clean:
+	rm -rf dist temp coverage


### PR DESCRIPTION
The `clean` target was declared in `.PHONY` (line 4) but had no recipe, so `make clean` produces `make: *** No rule to make target 'clean'.  Stop.` and `checkmake` flags the dangling phony declaration. The repository accumulates `dist/` (tsc output), `temp/` (MCP inspector probe), and `coverage/` (Jest output), none of which is git-ignored end-to-end at the developer level, so a recipe is useful as well as required.

The change adds a one-line recipe under the existing `.PHONY` declaration: `rm -rf dist temp coverage`. `make clean` now succeeds and the three transient directories disappear; `make` itself is unaffected because `all` does not depend on `clean`.

Verified locally with `npm install` followed by `make clean`, `make lint`, `make tsc`, and `make test` — the last three were already green on master and remain green after the recipe is added.

References #68 (`checkmake` root cause); the other three root causes named in #68 (`copyrights`, `eslint`, `make`/SDK transport) are not touched here and remain for a follow-up.
