### PR TITLE
#73: scope markdown-lint to master and trigger on pull requests

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -5,6 +5,11 @@
 name: markdown-lint
 'on':
   push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   markdown-lint:
     timeout-minutes: 15


### PR DESCRIPTION
The markdown-lint workflow currently runs on every branch push and never on pull requests, which means lint failures only surface after a merge and noisy runs fire for unrelated feature branches. Issue #73 asks for the same trigger shape that the other workflows in this repository already use.

This change updates `.github/workflows/markdown-lint.yml` so the `on:` block restricts `push` to the `master` branch and adds a `pull_request` trigger targeting `master`. Behaviour now matches `eslint.yml`, `make.yml` and the rest of the CI suite: contributors get markdown lint feedback inside the PR, and the workflow stops running on every side-branch push.

Local checks were run before pushing: `make test` (16 tests pass, 100% statement coverage), `make lint`, and `make tsc` all succeed. The `make it` step was skipped because `ZEROCRACY_TOKEN` is not available in this environment; the change is YAML-only and does not touch any TypeScript or test code.

Closes #73