### PR TITLE
#59: run project flat config in eslint workflow

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -16,6 +16,5 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - run: npm install -g eslint@9.17.0
-      - run: npm install @eslint/js@9.26.0
-      - run: eslint
+      - run: npm install
+      - run: npx eslint . --config eslint.config.mjs


### PR DESCRIPTION
Issue #59 tracks ESLint v10's strict flat-config requirement. The repository already ships `eslint.config.mjs` and pins `eslint ^10.0.0` in `package.json`, but `.github/workflows/eslint.yml` still does `npm install -g eslint@9.17.0` followed by a bare `eslint` invocation, so the hosted job runs ESLint v9 without a path and without `--config eslint.config.mjs`, never loading the project's flat config or its typescript-eslint rule set.

The workflow now does `npm install` and `npx eslint . --config eslint.config.mjs`, matching the `make lint` target. CI will exercise the same v10 flat config that local builds use, so future rule violations on PRs will surface in the hosted lint job instead of hiding behind a v9 default scan.

Verified locally on commit 3e248df: `npm install` installs `eslint@10.5.0`, `npx eslint . --config eslint.config.mjs` exits 0, `make test` reports 16/16 passing with 100% line coverage, and `make tsc` compiles without errors.

Closes #59