### PR TITLE
#81: remove stale liquibase extend-exclude from .github/typos.toml

### DIFF
--- a/.github/typos.toml
+++ b/.github/typos.toml
@@ -1,11 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 # SPDX-License-Identifier: MIT
-
-[files]
-extend-exclude = [
-  'liquibase/2024/035-swarm-unique.xml',
-  'liquibase/2025/053-more-indexes.xml'
-]
 
 [default.extend-words]
 WRONLY = "WRONLY"


### PR DESCRIPTION
Closes #81

Removes the `[files]\nextend-exclude` block that referenced nonexistent `liquibase/2024/035-swarm-unique.xml` and `liquibase/2025/053-more-indexes.xml` — leftover config from another project. Also updates the SPDX copyright year from 2025 to 2025-2026.

All existing `typos` CI checks should continue to pass (the exclude matched nothing, so removing it is a no-op for CI).