### PR TITLE
#83: remove deprecated :separateMajorMinor preset from renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    ":separateMajorMinor"
+    "config:recommended"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Closes #83

The `:separateMajorMinor` preset appears to have been removed in the current Renovate version used by this repository, causing Renovate to stop creating PRs. Removing it resolves the error — `config:recommended` already enables separate major/minor PRs by default.