### PR TITLE
#84: pin pdd-action and xcop-action to immutable refs

### DIFF
--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -16,4 +16,4 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: volodya-lombrozo/pdd-action@master
+      - uses: volodya-lombrozo/pdd-action@69842b56627431c5f232f5ea2dc2fca82f409c54 # no tags available

--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: g4s8/xcop-action@master
+      - uses: g4s8/xcop-action@v1.3
         with:
           files: '**/*.xml'


### PR DESCRIPTION
Closes #84

- `.github/workflows/pdd.yml`: pinned `volodya-lombrozo/pdd-action` from `@master` to commit SHA `69842b56` (no tagged releases available for this action)
- `.github/workflows/xcop.yml`: pinned `g4s8/xcop-action` from `@master` to `@v1.3` (latest release)

Both actions were previously pinned to the mutable `@master` ref. This change brings them in line with the other 10 workflows in this repo that all use pinned versions or tags.