### PR TITLE
#78: remove explicit globs from copyrights.yml to cover .ts files

### DIFF
--- a/.github/workflows/copyrights.yml
+++ b/.github/workflows/copyrights.yml
@@ -17,14 +17,3 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: yegor256/copyrights-action@0.0.12
-        with:
-          globs: >-
-            Dockerfile
-            LICENSE.txt
-            Makefile
-            Rakefile
-            **/*.sh
-            **/*.scss
-            **/*.rb
-            **/*.fe
-            **/*.yml

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S npx tsx
 
-// SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 // SPDX-License-Identifier: MIT
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";

--- a/test/fakes/FakeBaza.ts
+++ b/test/fakes/FakeBaza.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 Zerocracy
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 Zerocracy
 // SPDX-License-Identifier: MIT
 
 import { createServer, IncomingMessage, Server, ServerResponse } from 'node:http';


### PR DESCRIPTION
Closes #78

The explicit `globs:` in `copyrights.yml` did not include `**/*.ts`, so CI never checked copyright headers in TypeScript files. Removed the override entirely — upstream defaults cover `**/*.ts`, `**/*.js`, `**/*.html`, and more.

Additionally fixed the copyright year in `index.ts` and `test/fakes/FakeBaza.ts` from `2025` to `2025-2026` — these were missed before because the restricted globs never scanned them.