### PR TITLE
Add test for empty product list branch in resources.ts

### DIFF
--- a/test/resources.test.ts
+++ b/test/resources.test.ts
@@ -78,6 +78,26 @@ describe('resources', () => {
     expect(content).toHaveProperty('text');
   });
 
+  test('lists no resources when baza returns an empty product list', async (): Promise<void> => {
+    mock.mockImplementation(async (path, method, params, body) => {
+      if (path === '/products' && method === 'GET') {
+        return '';
+      }
+      if (path === '/mcp/resource' && method === 'PUT' && params.name === 'product') {
+        return `Details for product ${params.product}`;
+      }
+      return body;
+    });
+    const answer = await once({
+      jsonrpc: '2.0' as const,
+      id: 1,
+      method: 'resources/list'
+    });
+    expect(answer).toHaveProperty('result');
+    expect(answer.result).toHaveProperty('resources');
+    expect(answer.result?.resources).toEqual([]);
+  });
+
   test('filters empty products from trailing newlines', async (): Promise<void> => {
     mock.mockImplementation(async (path, method, params, body) => {
       if (path === '/products' && method === 'GET') {


### PR DESCRIPTION
## Summary

- Adds a test covering the case where `baza('/products', 'GET', ...)` returns an empty string, exercising the `else` side of the `if (csv.length !== 0)` branch in `src/resources.ts`.
- Restores branch coverage on `src/resources.ts` from 50% to 100%, fixing the `codecov/project` regression described in the issue (root cause: the ESM Jest preset switch changed how this untested branch was counted).

## Why

Issue #85 identified that `src/resources.ts:24` had only 50% branch coverage — the non-empty CSV path was tested, but the empty-string path (a product-less `baza` response) was not. This is recommendation #2 from the issue.

## Test plan

- [x] `make test` — all 22 tests pass (was 21; added 1)
- [x] Coverage report shows `resources.ts` at 100% branches/statements/functions/lines (was 50% branches)
- [x] `npx eslint . --config eslint.config.mjs` — no errors
- [x] `npx tsc --noEmit --project tsconfig.json` — no errors

Closes #85